### PR TITLE
add MC gen weight when plotting

### DIFF
--- a/python/spring15_13TeVconfig/general
+++ b/python/spring15_13TeVconfig/general
@@ -133,7 +133,7 @@ Datas: DYLL TTJets WJets WZ ZHbb ZZ
 #weightF: (puWeight*weightTrig2012*lheWeight)
 # weightF: (puWeight*weightTrig2012*lheWeight*weightSignalQCD*VHbb::ewkAtlas8TeVZllH(genH_pt,genZ.pt)*VHbb::ptWeightDY(lheV_pt)*VHbb::mueEff(Vtype,vLepton_eta[0],vLepton_eta[1],vLepton_pt[0],vLepton_pt[1]))
 # weightF: (puWeight*VHbb::ewkAtlas8TeVZllH(GenHiggsBoson_pt,GenVbosons_pt)*VHbb::ptWeightDY(lheV_pt)*VHbb::mueEff(Vtype,vLepton_eta[0],vLepton_eta[1],vLepton_pt[0],vLepton_pt[1]))
-weightF: (puWeight)
+weightF: (puWeight*genWeight)
 
 weightF_sys_UP: (puWeightP*weightTrig2012*lheWeight*weightSignalQCD*VHbb::ewkAtlas8TeVZllH(genH_pt,genZ.pt)*VHbb::ptWeightDY(lheV_pt)*VHbb::mueEff(Vtype,vLepton_eta[0],vLepton_eta[1],vLepton_pt[0],vLepton_pt[1]))
 weightF_sys_DOWN: (puWeightM*weightTrig2012*lheWeight*weightSignalQCD*VHbb::ewkAtlas8TeVZllH(genH_pt,genZ.pt)*VHbb::ptWeightDY(lheV_pt)*VHbb::mueEff(Vtype,vLepton_eta[0],vLepton_eta[1],vLepton_pt[0],vLepton_pt[1]))


### PR DESCRIPTION
I found the place where the weights are handled.
I am afraid that a problem remains when plotting, though.
If I look at the HistoMaker
https://github.com/GLP90/Xbb/blob/CMSSW_7_4_3/python/myutils/HistoMaker.py#L95
it uses TTree::Draw("var","weight*(cut)") option.
If the weights are either not all positive nor +/-1 and different for each MC sample,
I am afraid that the normalization is wrong.
I have to think about it. Do you have comments?